### PR TITLE
Minor code cleanup

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -393,7 +393,7 @@ impl Spell {
                     while let Some(&if_bits) = instructions_iter.next() {
                         match if_bits {
                             END_OF_SCOPE => break,
-                            TRUE..=FALSE => rpn_stack.push(if_bits), // true and false
+                            TRUE | FALSE => rpn_stack.push(if_bits), // true and false
                             NUMBER_LITERAL => rpn_stack.extend(vec![NUMBER_LITERAL, *instructions_iter.next().expect("Expected following value")]), // if 102, next bits are a number literal
                             COMPONENT => rpn_stack.extend(self.execute_component(&mut instructions_iter)?), // Component
                             AND => rpn_operations::binary_operation(&mut rpn_stack, boolean_logic::and).unwrap_or_else(|err| panic!("{}", err)), // And statement
@@ -466,7 +466,7 @@ impl Spell {
         for _ in 0..number_of_component_parameters {
             let parameter = *instructions_iter.next().expect("Expected parameter");
             match parameter {
-                TRUE..=FALSE => {},
+                TRUE | FALSE => {},
                 NUMBER_LITERAL => _ = *instructions_iter.next().expect("Expected number after number literal opcode"),
                 COMPONENT => _ = self.execute_component(instructions_iter),
                 _ => panic!("Invalid parameter skipped")
@@ -481,7 +481,7 @@ impl Spell {
         for parameter_number in 0..number_of_component_parameters {
             let parameter = *instructions_iter.next().expect("Expected parameter");
             match parameter {
-                TRUE..=FALSE => parameters.push(parameter),
+                TRUE | FALSE => parameters.push(parameter),
                 NUMBER_LITERAL => {
                     parameters.push(parameter);
                     parameters.push(*instructions_iter.next().expect("Expected number after number literal opcode"));
@@ -579,7 +579,7 @@ impl Spell {
         while let Some(&parameter) = parameter_iter.next() {
             match parameter {
                 NUMBER_LITERAL => compressed_parameters.push(*parameter_iter.next().expect("Expected parameter after number literal opcode")),
-                TRUE..=FALSE => compressed_parameters.push(parameter),
+                TRUE | FALSE => compressed_parameters.push(parameter),
                 _ => panic!("Invalid parameter: isn't float or boolean")
             }
         }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,11 +384,11 @@ impl Spell {
         let mut instructions_iter = instructions.iter();
         while let Some(&bits) = instructions_iter.next() {
             match bits {
-                0 => {}, // 0 = end of scope, if reached naturely, move on
-                103 => { // 103 = component
+                END_OF_SCOPE => {}, // 0 = end of scope, if reached naturely, move on
+                COMPONENT => { // 103 = component
                     self.execute_component(&mut instructions_iter)?;
                 },
-                400 => { // 400 = if statement
+                IF => { // 400 = if statement
                     let mut rpn_stack: Vec<u64> = Vec::new();
                     while let Some(&if_bits) = instructions_iter.next() {
                         match if_bits {
@@ -740,7 +740,7 @@ impl Spell {
         let mut instructions_iter = instructions.iter();
         let mut section: Option<u64> = None;
         while let Some(&bits) = instructions_iter.next() {
-            if section.is_some_and(|x| x == 502) && !(500..=599).contains(&bits)  { // ignore all checks in metadata section
+            if section.is_some_and(|x| x == METADATA_SECTION) && !(READY_SECTION..=599).contains(&bits)  { // ignore all checks in metadata section
                 continue;
             }
             match bits {

--- a/src/spelltranslator.rs
+++ b/src/spelltranslator.rs
@@ -312,7 +312,7 @@ fn test_execute_component<'a>(instructions_iter: &mut impl Iterator<Item = &'a u
         let parameter = *instructions_iter.next().ok_or("expected parameter")?;
 
         match parameter {
-            TRUE..=FALSE => parameters.push(parameter),
+            TRUE | FALSE => parameters.push(parameter),
             NUMBER_LITERAL => {
                 parameters.push(parameter);
                 parameters.push(*instructions_iter.next().ok_or("Expected number after number literal opcode")?);
@@ -341,7 +341,7 @@ fn test_logic(logic: &Vec<u64>) -> Result<(), &'static str> {
     while let Some(&if_bits) = instructions_iter.next() {
         match if_bits {
             END_OF_SCOPE => break,
-            TRUE..=FALSE => rpn_stack.push(if_bits), // true and false
+            TRUE | FALSE => rpn_stack.push(if_bits), // true and false
             NUMBER_LITERAL => rpn_stack.extend(vec![NUMBER_LITERAL, *instructions_iter.next().ok_or("Expected following value")?]), // if 102, next bits are a number literal
             COMPONENT => rpn_stack.extend(test_execute_component(&mut instructions_iter)?), // Component
             AND => rpn_operations::binary_operation(&mut rpn_stack, boolean_logic::and)?, // And statement


### PR DESCRIPTION
Refactored 
- color parsing
- selective match statement patterns
- remaining numbered constants from #43

### Notice of Unnamed Constants
There are still unnamed constants, mainly 0, in spelltranslator.rs which are I could not distinguish from END_OF_SCOPE code or a literal 0