### PR TITLE
Add string translation

### DIFF
--- a/src/codes.rs
+++ b/src/codes.rs
@@ -1,5 +1,5 @@
 pub mod componentcodes;
 pub mod opcodes;
 pub mod attributecodes;
-pub mod shapecodes;
+pub mod component_specific_codes;
 pub mod datatypes;

--- a/src/codes/component_specific_codes.rs
+++ b/src/codes/component_specific_codes.rs
@@ -1,2 +1,3 @@
+// Shapes
 pub const SPHERE: u64 = 0;
 pub const CUBE: u64 = 1;

--- a/src/component_functions.rs
+++ b/src/component_functions.rs
@@ -1,6 +1,6 @@
 use godot::prelude::*;
 
-use crate::{Spell, codes::opcodes::*, codes::shapecodes::*, Shape, Sphere, Cube, HasShape};
+use crate::{Spell, codes::opcodes::*, codes::component_specific_codes::*, Shape, Sphere, Cube, HasShape};
 
 const APPLY_TO_SPELL_COEFFICIENT: f64 = 70.0;
 

--- a/src/spelltranslator.rs
+++ b/src/spelltranslator.rs
@@ -1,6 +1,6 @@
 use lazy_static::lazy_static;
 use std::collections::HashMap;
-use crate::{boolean_logic, codes::{attributecodes::*, componentcodes::*, opcodes::*, datatypes::*}, rpn_operations, ReturnType, Spell, COMPONENT_TO_FUNCTION_MAP};
+use crate::{boolean_logic, codes::{attributecodes::*, componentcodes::*, opcodes::*, datatypes::*, component_specific_codes::*}, rpn_operations, ReturnType, Spell, COMPONENT_TO_FUNCTION_MAP};
 
 const NAME_SIZE: usize = 25;
 
@@ -45,14 +45,32 @@ struct List {
 }
 
 lazy_static! {
-    /// Maps attribute name to (attribute_code, datatype, size)
-    static ref ATTRIBUTES_MAP: HashMap<[Option<char>; NAME_SIZE], (u64, Datatype)> = {
+    /// Maps attribute name to (attribute_code, datatype)
+    static ref ATTRIBUTE_MAP: HashMap<[Option<char>; NAME_SIZE], (u64, Datatype)> = {
         let mut attribute_map = HashMap::new();
 
         attribute_map.insert(pad_name("color"), (COLOR, Datatype::List(List { datatype: FLOAT, size: 3 })));
         attribute_map.insert(pad_name("colour"), (COLOR, Datatype::List(List { datatype: FLOAT, size: 3 })));
         attribute_map.insert(pad_name("charge_to_shape"), (CHARGE_TO_SHAPE, Datatype::Boolean));
         attribute_map
+    };
+}
+
+lazy_static! {
+    /// Maps a component_code to a map that maps strings to values (and by strings I actually mean arrays of characters)
+    static ref STRING_MAP: HashMap<u64, HashMap<[Option<char>; NAME_SIZE], u64>> = {
+        let mut string_map = HashMap::new();
+
+        string_map.insert(TAKE_SHAPE, {
+            let mut string_map = HashMap::new();
+
+            string_map.insert(pad_name("sphere"), SPHERE);
+            string_map.insert(pad_name("cube"), CUBE);
+
+            string_map
+        });
+
+        string_map
     };
 }
 
@@ -69,7 +87,7 @@ pub fn get_component_num(component_name: &str) -> Option<u64> {
 }
 
 fn get_attribute_info(attribute_name: &str) -> Option<&(u64, Datatype)> {
-    ATTRIBUTES_MAP.get(&pad_name(attribute_name))
+    ATTRIBUTE_MAP.get(&pad_name(attribute_name))
 }
 
 pub fn parse_spell(spell_code: &str) -> Result<Vec<u64>, &'static str> {


### PR DESCRIPTION
# String translation
This pull request closes #14.

## Done so far
- Changed `shapecodes` to `component_specific_codes`
- Made a `STRING_MAP`, designed to be queried whenever a string comes up as a parameter in a component

## Missing
- The parameter translation code